### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,18 +13,18 @@
 # Datatypes (KEYWORD5 or KEYWORD1)
 ########################################
 
-ExampleLibrary                  KEYWORD1
+ExampleLibrary	KEYWORD1
 
 ########################################
 # Methods and Functions
 #   (FUNCTION2 or KEYWORD2)
 ########################################
 
-doThatThing                     KEYWORD2
+doThatThing	KEYWORD2
 
 ########################################
 # Constants (LITERAL2)
 ########################################
 
-FORWARD                         LITERAL2
-BACKWARD                        LITERAL2
+FORWARD	LITERAL2
+BACKWARD	LITERAL2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords